### PR TITLE
Port forward as SessionHandler interface

### DIFF
--- a/app/daemon.go
+++ b/app/daemon.go
@@ -77,6 +77,7 @@ type MenderShellDaemon struct {
 	router                  session.Router
 	config.TerminalConfig
 	config.FileTransferConfig
+	config.PortForwardConfig
 	config.MenderClientConfig
 }
 
@@ -92,6 +93,9 @@ func NewDaemon(conf *config.MenderShellConfig) *MenderShellDaemon {
 	}
 	if !conf.FileTransfer.Disable {
 		routes[ws.ProtoTypeFileTransfer] = session.FileTransfer()
+	}
+	if !conf.PortForward.Disable {
+		routes[ws.ProtoTypePortForward] = session.PortForward()
 	}
 	if !conf.MenderClient.Disable {
 		routes[ws.ProtoTypeMenderClient] = session.MenderClient()
@@ -121,6 +125,9 @@ func NewDaemon(conf *config.MenderShellConfig) *MenderShellDaemon {
 		deviceConnectUrl:        config.DefaultDeviceConnectPath,
 		terminalString:          config.DefaultTerminalString,
 		TerminalConfig:          conf.Terminal,
+		FileTransferConfig:      conf.FileTransfer,
+		PortForwardConfig:       conf.PortForward,
+		MenderClientConfig:      conf.MenderClient,
 		shellsSpawned:           0,
 		debug:                   conf.Debug,
 		trace:                   conf.Trace,

--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,11 @@ type FileTransferConfig struct {
 	Disable bool
 }
 
+type PortForwardConfig struct {
+	// Disable port forwarding feature
+	Disable bool
+}
+
 type SessionsConfig struct {
 	// Whether to stop expired sessions
 	StopExpired bool
@@ -84,9 +89,11 @@ type MenderShellConfigFromFile struct {
 	Sessions SessionsConfig `json:"Sessions"`
 	// Reconnect interval
 	ReconnectIntervalSeconds int
-
+	// FileTransfer config
 	FileTransfer FileTransferConfig
-
+	// PortForward config
+	PortForward PortForwardConfig
+	// MenderClient config
 	MenderClient MenderClientConfig
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/creack/pty v1.1.11
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/gorilla/websocket v1.4.2
-	github.com/mendersoftware/go-lib-micro v0.0.0-20210317131202-d8b47cfebb37
+	github.com/mendersoftware/go-lib-micro v0.0.0-20210319123318-8cee8f55d7f5
 	github.com/pkg/errors v0.9.1
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.8.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/creack/pty v1.1.11
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/gorilla/websocket v1.4.2
-	github.com/mendersoftware/go-lib-micro v0.0.0-20210311084510-06d0c5918746
+	github.com/mendersoftware/go-lib-micro v0.0.0-20210317131202-d8b47cfebb37
 	github.com/pkg/errors v0.9.1
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -169,10 +169,8 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mendersoftware/cli/v2 v2.1.1-minimal h1:NWX83kF8Eobfb3oBWeUmw9Ef2H9ZqFPZGWRXCimtXwg=
 github.com/mendersoftware/cli/v2 v2.1.1-minimal/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
-github.com/mendersoftware/go-lib-micro v0.0.0-20210310094411-54024edff7ea h1:FkE2jfmmmKkgPEzje2XfH6/RMnR0Z+fV9FOgRiz277c=
-github.com/mendersoftware/go-lib-micro v0.0.0-20210310094411-54024edff7ea/go.mod h1:AYMV1BNNHDcAt25V7KY6cd5XhAZXIlOVlCV9yZt51zM=
-github.com/mendersoftware/go-lib-micro v0.0.0-20210311084510-06d0c5918746 h1:P6zxuOT3ATh8AnYZTI95iLnH0kEo7BWno/U6iytqIuI=
-github.com/mendersoftware/go-lib-micro v0.0.0-20210311084510-06d0c5918746/go.mod h1:AYMV1BNNHDcAt25V7KY6cd5XhAZXIlOVlCV9yZt51zM=
+github.com/mendersoftware/go-lib-micro v0.0.0-20210317131202-d8b47cfebb37 h1:vT2UmT4zNBkqQYpD9FSCt9IDU20rd7jjwFTExCHisfg=
+github.com/mendersoftware/go-lib-micro v0.0.0-20210317131202-d8b47cfebb37/go.mod h1:AYMV1BNNHDcAt25V7KY6cd5XhAZXIlOVlCV9yZt51zM=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ github.com/mendersoftware/cli/v2 v2.1.1-minimal h1:NWX83kF8Eobfb3oBWeUmw9Ef2H9Zq
 github.com/mendersoftware/cli/v2 v2.1.1-minimal/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/mendersoftware/go-lib-micro v0.0.0-20210317131202-d8b47cfebb37 h1:vT2UmT4zNBkqQYpD9FSCt9IDU20rd7jjwFTExCHisfg=
 github.com/mendersoftware/go-lib-micro v0.0.0-20210317131202-d8b47cfebb37/go.mod h1:AYMV1BNNHDcAt25V7KY6cd5XhAZXIlOVlCV9yZt51zM=
+github.com/mendersoftware/go-lib-micro v0.0.0-20210319123318-8cee8f55d7f5 h1:ggqfF3oHRWyahqgvzdLuHRlhGWv92e5Eos9fNnB+57k=
+github.com/mendersoftware/go-lib-micro v0.0.0-20210319123318-8cee8f55d7f5/go.mod h1:AYMV1BNNHDcAt25V7KY6cd5XhAZXIlOVlCV9yZt51zM=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/session/portforward.go
+++ b/session/portforward.go
@@ -1,0 +1,282 @@
+// Copyright 2021 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package session
+
+import (
+	"context"
+	"io"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/mendersoftware/go-lib-micro/ws"
+	wspf "github.com/mendersoftware/go-lib-micro/ws/portforward"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	protocolTCP = "tcp"
+	protocolUDP = "udp"
+)
+
+const (
+	portForwardBuffSize          = 4096
+	portForwardConnectionTimeout = time.Second * 600
+)
+
+var (
+	errPortForwardInvalidMessage     = errors.New("invalid port-forward message: missing connection_id, remort_port or protocol")
+	errPortForwardUnkonwnMessageType = errors.New("unknown message type")
+	errPortForwardUnkonwnConnection  = errors.New("unknown connection")
+)
+
+var portForwarders = make(map[string]*MenderPortForwarder)
+
+type MenderPortForwarder struct {
+	ConnectionID   string
+	SessionID      string
+	ResponseWriter ResponseWriter
+	conn           net.Conn
+	ctx            context.Context
+	ctxCancel      context.CancelFunc
+}
+
+func (f *MenderPortForwarder) Connect(protocol string, host string, portNumber int) error {
+	log.Debugf("port-forward[%s/%s] connect: %s/%s:%d", f.SessionID, f.ConnectionID, protocol, host, portNumber)
+
+	if protocol == protocolTCP || protocol == protocolUDP {
+		conn, err := net.Dial(protocol, host+":"+strconv.Itoa(portNumber))
+		if err != nil {
+			return err
+		}
+		f.conn = conn
+	} else {
+		return errors.New("unknown protocol: " + protocol)
+	}
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	f.ctx = ctx
+	f.ctxCancel = cancelFunc
+
+	go f.Read()
+
+	return nil
+}
+
+func (f *MenderPortForwarder) Close(sendStopMessage bool) error {
+	log.Debugf("port-forward[%s/%s] close", f.SessionID, f.ConnectionID)
+	if sendStopMessage {
+		m := &ws.ProtoMsg{
+			Header: ws.ProtoHdr{
+				Proto:     ws.ProtoTypePortForward,
+				MsgType:   wspf.MessageTypePortForwardStop,
+				SessionID: f.SessionID,
+				Properties: map[string]interface{}{
+					wspf.PropertyPortForwardConnectionID: f.ConnectionID,
+				},
+			},
+		}
+		if err := f.ResponseWriter.WriteProtoMsg(m); err != nil {
+			log.Errorf("portForwardHandler: webSock.WriteMessage(%+v)", err)
+		}
+	}
+	defer delete(portForwarders, f.SessionID+"/"+f.ConnectionID)
+	f.ctxCancel()
+	return f.conn.Close()
+}
+
+func (f *MenderPortForwarder) Read() {
+	errChan := make(chan error)
+	dataChan := make(chan []byte)
+
+	go func() {
+		data := make([]byte, portForwardBuffSize)
+
+		for {
+			n, err := f.conn.Read(data)
+			if err != nil {
+				errChan <- err
+				break
+			}
+			if n > 0 {
+				dataChan <- data[:n]
+			}
+		}
+	}()
+
+	for {
+		select {
+		case err := <-errChan:
+			if err != io.EOF {
+				log.Errorf("port-forward[%s/%s] error: %v\n", f.SessionID, f.ConnectionID, err.Error())
+			}
+			f.Close(true)
+		case data := <-dataChan:
+			log.Debugf("port-forward[%s/%s] read %d bytes", f.SessionID, f.ConnectionID, len(data))
+
+			m := &ws.ProtoMsg{
+				Header: ws.ProtoHdr{
+					Proto:     ws.ProtoTypePortForward,
+					MsgType:   wspf.MessageTypePortForward,
+					SessionID: f.SessionID,
+					Properties: map[string]interface{}{
+						wspf.PropertyPortForwardConnectionID: f.ConnectionID,
+					},
+				},
+				Body: data,
+			}
+			if err := f.ResponseWriter.WriteProtoMsg(m); err != nil {
+				log.Errorf("portForwardHandler: webSock.WriteMessage(%+v)", err)
+			}
+		case <-time.After(portForwardConnectionTimeout):
+			f.Close(true)
+		case <-f.ctx.Done():
+			return
+		}
+	}
+}
+
+func (f *MenderPortForwarder) Write(body []byte) error {
+	log.Debugf("port-forward[%s/%s] write %d bytes", f.SessionID, f.ConnectionID, len(body))
+	_, err := f.conn.Write(body)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func PortForward() Constructor {
+	f := HandlerFunc(portForwardHandler)
+	return func() SessionHandler { return f }
+}
+
+func portForwardHandler(msg *ws.ProtoMsg, w ResponseWriter) {
+	var err error
+	switch msg.Header.MsgType {
+	case wspf.MessageTypePortForwardNew:
+		err = portForwardHandlerNew(msg, w)
+	case wspf.MessageTypePortForwardStop:
+		err = portForwardHandlerStop(msg, w)
+	case wspf.MessageTypePortForward:
+		err = portForwardHandlerForward(msg, w)
+	default:
+		err = errPortForwardUnkonwnMessageType
+	}
+	if err != nil {
+		log.Errorf("portForwardHandler(%+v)", err)
+
+		response := &ws.ProtoMsg{
+			Header: ws.ProtoHdr{
+				Proto:      ws.ProtoTypePortForward,
+				MsgType:    ws.MessageTypeError,
+				SessionID:  msg.Header.SessionID,
+				Properties: msg.Header.Properties,
+			},
+			Body: []byte(err.Error()),
+		}
+		if err := w.WriteProtoMsg(response); err != nil {
+			log.Errorf("portForwardHandler: webSock.WriteMessage(%+v)", err)
+		}
+	}
+}
+
+func getConnectionIDFromMessage(message *ws.ProtoMsg) string {
+	connectionID, _ := message.Header.Properties[wspf.PropertyPortForwardConnectionID].(string)
+	return connectionID
+}
+
+func portForwardHandlerNew(message *ws.ProtoMsg, w ResponseWriter) error {
+	connectionID := getConnectionIDFromMessage(message)
+	protocol, _ := message.Header.Properties[wspf.PropertyPortForwardProtocol].(string)
+	host, _ := message.Header.Properties[wspf.PropertyPortForwardRemoteHost].(string)
+	portNumber, _ := message.Header.Properties[wspf.PropertyPortForwardRemotePort].(uint64)
+
+	if connectionID == "" || portNumber == 0 || protocol == "" {
+		return errPortForwardInvalidMessage
+	}
+
+	portForwarder := &MenderPortForwarder{
+		ConnectionID:   connectionID,
+		SessionID:      message.Header.SessionID,
+		ResponseWriter: w,
+	}
+
+	key := message.Header.SessionID + "/" + connectionID
+	portForwarders[key] = portForwarder
+
+	log.Infof("port-forward: new %s: %s/%s:%d", key, protocol, host, portNumber)
+	err := portForwarder.Connect(protocol, host, int(portNumber))
+	if err != nil {
+		delete(portForwarders, key)
+		return err
+	}
+
+	response := &ws.ProtoMsg{
+		Header: ws.ProtoHdr{
+			Proto:     message.Header.Proto,
+			MsgType:   message.Header.MsgType,
+			SessionID: message.Header.SessionID,
+			Properties: map[string]interface{}{
+				wspf.PropertyPortForwardConnectionID: connectionID,
+			},
+		},
+	}
+	if err := w.WriteProtoMsg(response); err != nil {
+		log.Errorf("portForwardHandler: webSock.WriteMessage(%+v)", err)
+	}
+
+	return nil
+}
+
+func portForwardHandlerStop(message *ws.ProtoMsg, w ResponseWriter) error {
+	connectionID := getConnectionIDFromMessage(message)
+	key := message.Header.SessionID + "/" + connectionID
+	if portForwarder, ok := portForwarders[key]; ok {
+		log.Infof("port-forward: stop %s", key)
+		defer delete(portForwarders, key)
+		if err := portForwarder.Close(false); err != nil {
+			return err
+		}
+
+		response := &ws.ProtoMsg{
+			Header: ws.ProtoHdr{
+				Proto:     message.Header.Proto,
+				MsgType:   message.Header.MsgType,
+				SessionID: message.Header.SessionID,
+				Properties: map[string]interface{}{
+					wspf.PropertyPortForwardConnectionID: connectionID,
+				},
+			},
+		}
+		if err := w.WriteProtoMsg(response); err != nil {
+			log.Errorf("portForwardHandler: webSock.WriteMessage(%+v)", err)
+		}
+
+		return nil
+	} else {
+		return errPortForwardUnkonwnConnection
+	}
+}
+
+func portForwardHandlerForward(message *ws.ProtoMsg, w ResponseWriter) error {
+	connectionID := getConnectionIDFromMessage(message)
+	key := message.Header.SessionID + "/" + connectionID
+	if portForwarder, ok := portForwarders[key]; ok {
+		return portForwarder.Write(message.Body)
+	} else {
+		return errPortForwardUnkonwnConnection
+	}
+}

--- a/session/portforward_test.go
+++ b/session/portforward_test.go
@@ -1,0 +1,316 @@
+// Copyright 2021 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package session
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mendersoftware/go-lib-micro/ws"
+	wspf "github.com/mendersoftware/go-lib-micro/ws/portforward"
+	"github.com/stretchr/testify/assert"
+)
+
+func getFreeTCPPort() int {
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		panic(err)
+	}
+	defer listener.Close()
+
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func TestPortForwardHandler(t *testing.T) {
+	// unkonwn message
+	msg := &ws.ProtoMsg{
+		Header: ws.ProtoHdr{
+			Proto:   ws.ProtoTypePortForward,
+			MsgType: "dummy",
+		},
+	}
+	w := new(testWriter)
+	portForwardHandler(msg, w)
+	if !assert.Len(t, w.Messages, 1) {
+		t.FailNow()
+	}
+	rsp := w.Messages[0]
+	assert.Equal(t, ws.ProtoTypePortForward, rsp.Header.Proto)
+	assert.Equal(t, ws.MessageTypeError, rsp.Header.MsgType)
+	assert.Equal(t, errPortForwardUnkonwnMessageType.Error(), string(rsp.Body))
+	// new
+	msg = &ws.ProtoMsg{
+		Header: ws.ProtoHdr{
+			Proto:   ws.ProtoTypePortForward,
+			MsgType: wspf.MessageTypePortForwardNew,
+			Properties: map[string]interface{}{
+				wspf.PropertyPortForwardConnectionID: "c1",
+				wspf.PropertyPortForwardProtocol:     protocolTCP,
+				wspf.PropertyPortForwardRemoteHost:   "localhost",
+				wspf.PropertyPortForwardRemotePort:   uint64(getFreeTCPPort()),
+			},
+		},
+	}
+	w = new(testWriter)
+	portForwardHandler(msg, w)
+	if !assert.Len(t, w.Messages, 1) {
+		t.FailNow()
+	}
+	rsp = w.Messages[0]
+	assert.Equal(t, ws.ProtoTypePortForward, rsp.Header.Proto)
+	assert.Equal(t, ws.MessageTypeError, rsp.Header.MsgType)
+	assert.Contains(t, string(rsp.Body), "connect: connection refused")
+	// stop
+	msg = &ws.ProtoMsg{
+		Header: ws.ProtoHdr{
+			Proto:   ws.ProtoTypePortForward,
+			MsgType: wspf.MessageTypePortForwardStop,
+		},
+	}
+	w = new(testWriter)
+	portForwardHandler(msg, w)
+	if !assert.Len(t, w.Messages, 1) {
+		t.FailNow()
+	}
+	rsp = w.Messages[0]
+	assert.Equal(t, ws.ProtoTypePortForward, rsp.Header.Proto)
+	assert.Equal(t, ws.MessageTypeError, rsp.Header.MsgType)
+	assert.Equal(t, errPortForwardUnkonwnConnection.Error(), string(rsp.Body))
+	// forward
+	msg = &ws.ProtoMsg{
+		Header: ws.ProtoHdr{
+			Proto:   ws.ProtoTypePortForward,
+			MsgType: wspf.MessageTypePortForward,
+		},
+	}
+	w = new(testWriter)
+	portForwardHandler(msg, w)
+	if !assert.Len(t, w.Messages, 1) {
+		t.FailNow()
+	}
+	rsp = w.Messages[0]
+	assert.Equal(t, ws.ProtoTypePortForward, rsp.Header.Proto)
+	assert.Equal(t, ws.MessageTypeError, rsp.Header.MsgType)
+	assert.Equal(t, errPortForwardUnkonwnConnection.Error(), string(rsp.Body))
+}
+
+func TestPortForwardHandlerSuccessfulConnection(t *testing.T) {
+	// mock echo TCP server
+	tcpPort := getFreeTCPPort()
+	go func(tcpPort int) {
+		l, err := net.Listen(protocolTCP, fmt.Sprintf("localhost:%d", tcpPort))
+		if err != nil {
+			panic(err)
+		}
+		defer l.Close()
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				panic(err)
+			}
+			go func(conn net.Conn) {
+				buf := make([]byte, 1024)
+				for {
+					n, err := conn.Read(buf)
+					if err != nil && err == io.EOF {
+						return
+					} else if err != nil {
+						panic(err)
+					}
+					response := strings.ToUpper(string(buf[:n]))
+					_, err = conn.Write([]byte(response))
+					if err != nil {
+						panic(err)
+					}
+					if response == "STOP" {
+						time.Sleep(50 * time.Millisecond)
+						conn.Close()
+						return
+					}
+				}
+			}(conn)
+		}
+	}(tcpPort)
+
+	sessionID := "session_id"
+
+	// c1: new
+	msg := &ws.ProtoMsg{
+		Header: ws.ProtoHdr{
+			Proto:     ws.ProtoTypePortForward,
+			MsgType:   wspf.MessageTypePortForwardNew,
+			SessionID: sessionID,
+			Properties: map[string]interface{}{
+				wspf.PropertyPortForwardConnectionID: "c1",
+				wspf.PropertyPortForwardProtocol:     protocolTCP,
+				wspf.PropertyPortForwardRemoteHost:   "localhost",
+				wspf.PropertyPortForwardRemotePort:   uint64(tcpPort),
+			},
+		},
+	}
+	w := new(testWriter)
+	portForwardHandler(msg, w)
+
+	time.Sleep(100 * time.Millisecond)
+	if !assert.Len(t, w.Messages, 1) {
+		t.FailNow()
+	}
+
+	rsp := w.Messages[0]
+	assert.Equal(t, ws.ProtoTypePortForward, rsp.Header.Proto)
+	assert.Equal(t, wspf.MessageTypePortForwardNew, rsp.Header.MsgType)
+	assert.Nil(t, rsp.Body)
+
+	// c1: forward
+	msg = &ws.ProtoMsg{
+		Header: ws.ProtoHdr{
+			Proto:     ws.ProtoTypePortForward,
+			MsgType:   wspf.MessageTypePortForward,
+			SessionID: sessionID,
+			Properties: map[string]interface{}{
+				wspf.PropertyPortForwardConnectionID: "c1",
+			},
+		},
+		Body: []byte("abcdefghi"),
+	}
+	w.Messages = []*ws.ProtoMsg{}
+	portForwardHandler(msg, w)
+
+	time.Sleep(100 * time.Millisecond)
+	if !assert.Len(t, w.Messages, 1) {
+		t.FailNow()
+	}
+
+	rsp = w.Messages[0]
+	assert.Equal(t, ws.ProtoTypePortForward, rsp.Header.Proto)
+	assert.Equal(t, wspf.MessageTypePortForward, rsp.Header.MsgType)
+	assert.Equal(t, "c1", rsp.Header.Properties[wspf.PropertyPortForwardConnectionID].(string))
+	assert.Equal(t, []byte("ABCDEFGHI"), rsp.Body)
+
+	// c2: new
+	msg = &ws.ProtoMsg{
+		Header: ws.ProtoHdr{
+			Proto:     ws.ProtoTypePortForward,
+			MsgType:   wspf.MessageTypePortForwardNew,
+			SessionID: sessionID,
+			Properties: map[string]interface{}{
+				wspf.PropertyPortForwardConnectionID: "c2",
+				wspf.PropertyPortForwardProtocol:     protocolTCP,
+				wspf.PropertyPortForwardRemoteHost:   "localhost",
+				wspf.PropertyPortForwardRemotePort:   uint64(tcpPort),
+			},
+		},
+	}
+	w.Messages = []*ws.ProtoMsg{}
+	portForwardHandler(msg, w)
+
+	time.Sleep(100 * time.Millisecond)
+	if !assert.Len(t, w.Messages, 1) {
+		t.FailNow()
+	}
+
+	rsp = w.Messages[0]
+	assert.Equal(t, ws.ProtoTypePortForward, rsp.Header.Proto)
+	assert.Equal(t, wspf.MessageTypePortForwardNew, rsp.Header.MsgType)
+	assert.Equal(t, "c2", rsp.Header.Properties[wspf.PropertyPortForwardConnectionID].(string))
+	assert.Nil(t, rsp.Body)
+
+	// c1: forward, again
+	msg = &ws.ProtoMsg{
+		Header: ws.ProtoHdr{
+			Proto:     ws.ProtoTypePortForward,
+			MsgType:   wspf.MessageTypePortForward,
+			SessionID: sessionID,
+			Properties: map[string]interface{}{
+				wspf.PropertyPortForwardConnectionID: "c1",
+			},
+		},
+		Body: []byte("1234"),
+	}
+	w.Messages = []*ws.ProtoMsg{}
+	portForwardHandler(msg, w)
+
+	time.Sleep(100 * time.Millisecond)
+	if !assert.Len(t, w.Messages, 1) {
+		t.FailNow()
+	}
+
+	rsp = w.Messages[0]
+	assert.Equal(t, ws.ProtoTypePortForward, rsp.Header.Proto)
+	assert.Equal(t, wspf.MessageTypePortForward, rsp.Header.MsgType)
+	assert.Equal(t, "c1", rsp.Header.Properties[wspf.PropertyPortForwardConnectionID].(string))
+	assert.Equal(t, []byte("1234"), rsp.Body)
+
+	// c1: stop
+	msg = &ws.ProtoMsg{
+		Header: ws.ProtoHdr{
+			Proto:     ws.ProtoTypePortForward,
+			MsgType:   wspf.MessageTypePortForwardStop,
+			SessionID: sessionID,
+			Properties: map[string]interface{}{
+				wspf.PropertyPortForwardConnectionID: "c1",
+			},
+		},
+	}
+	w.Messages = []*ws.ProtoMsg{}
+	portForwardHandler(msg, w)
+
+	time.Sleep(100 * time.Millisecond)
+	if !assert.Len(t, w.Messages, 1) {
+		t.FailNow()
+	}
+
+	rsp = w.Messages[0]
+	assert.Equal(t, ws.ProtoTypePortForward, rsp.Header.Proto)
+	assert.Equal(t, wspf.MessageTypePortForwardStop, rsp.Header.MsgType)
+	assert.Equal(t, "c1", rsp.Header.Properties[wspf.PropertyPortForwardConnectionID].(string))
+	assert.Nil(t, rsp.Body)
+
+	// c2: forward the message with the "stop" payload
+	msg = &ws.ProtoMsg{
+		Header: ws.ProtoHdr{
+			Proto:     ws.ProtoTypePortForward,
+			MsgType:   wspf.MessageTypePortForward,
+			SessionID: sessionID,
+			Properties: map[string]interface{}{
+				wspf.PropertyPortForwardConnectionID: "c2",
+			},
+		},
+		Body: []byte("stop"),
+	}
+	w.Messages = []*ws.ProtoMsg{}
+	portForwardHandler(msg, w)
+
+	time.Sleep(100 * time.Millisecond)
+	if !assert.Len(t, w.Messages, 2) {
+		t.FailNow()
+	}
+
+	rsp = w.Messages[0]
+	assert.Equal(t, ws.ProtoTypePortForward, rsp.Header.Proto)
+	assert.Equal(t, wspf.MessageTypePortForward, rsp.Header.MsgType)
+	assert.Equal(t, "c2", rsp.Header.Properties[wspf.PropertyPortForwardConnectionID].(string))
+	assert.Equal(t, []byte("STOP"), rsp.Body)
+
+	rsp = w.Messages[1]
+	assert.Equal(t, ws.ProtoTypePortForward, rsp.Header.Proto)
+	assert.Equal(t, wspf.MessageTypePortForwardStop, rsp.Header.MsgType)
+	assert.Equal(t, "c2", rsp.Header.Properties[wspf.PropertyPortForwardConnectionID].(string))
+	assert.Nil(t, rsp.Body)
+}

--- a/vendor/github.com/mendersoftware/go-lib-micro/ws/portforward/model.go
+++ b/vendor/github.com/mendersoftware/go-lib-micro/ws/portforward/model.go
@@ -15,14 +15,38 @@
 package portforward
 
 const (
-	MessageTypePortForwardNew  = "new"
+	// MessageTypePortForwardNew is the message type to start a port-forwarding connection
+	// The body MUST contain a PortForwardNew object.
+	MessageTypePortForwardNew = "new"
+	// MessageTypePortForwardStop is the message type to stop a port-forwarding connection
 	MessageTypePortForwardStop = "stop"
-	MessageTypePortForward     = "forward"
+	// MessageTypePortForward is the message type for streaming data
+	MessageTypePortForward = "forward"
+	// MessageTypeError is returned on internal or protocol errors. The
+	// body MUST contain an Error object.
+	MessageTypeError = "error"
 )
 
+// PortForwardProtocol stores the protocol
+type PortForwardProtocol string
+
+// Values for the PortForwardProtocol type
 const (
-	PropertyPortForwardConnectionID = "connection_id"
-	PropertyPortForwardRemoteHost   = "remote_host"
-	PropertyPortForwardRemotePort   = "remote_port"
-	PropertyPortForwardProtocol     = "protocol"
+	PortForwardProtocolTCP = "tcp"
+	PortForwardProtocolUDP = "udp"
 )
+
+// PortForwardNew represents a new port forwarding request
+type PortForwardNew struct {
+	RemoteHost *string              `msgpack:"remote_host" json:"remote_host"`
+	RemotePort *uint                `msgpack:"remote_port" json:"remote_port"`
+	Protocol   *PortForwardProtocol `msgpack:"protocol" json:"protocol"`
+}
+
+// Error struct is passed in the Body of MsgProto in case the message type is ErrorMessage
+type Error struct {
+	// The error description, as in "Permission denied while opening a file"
+	Error *string `msgpack:"err" json:"error"`
+	// Type of message that raised the error
+	MessageType *string `msgpack:"msgtype,omitempty" json:"message_type,omitempty"`
+}

--- a/vendor/github.com/mendersoftware/go-lib-micro/ws/portforward/model.go
+++ b/vendor/github.com/mendersoftware/go-lib-micro/ws/portforward/model.go
@@ -1,0 +1,28 @@
+// Copyright 2021 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package portforward
+
+const (
+	MessageTypePortForwardNew  = "new"
+	MessageTypePortForwardStop = "stop"
+	MessageTypePortForward     = "forward"
+)
+
+const (
+	PropertyPortForwardConnectionID = "connection_id"
+	PropertyPortForwardRemoteHost   = "remote_host"
+	PropertyPortForwardRemotePort   = "remote_port"
+	PropertyPortForwardProtocol     = "protocol"
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,11 +12,12 @@ github.com/gorilla/websocket
 # github.com/magefile/mage v1.10.0
 github.com/magefile/mage/mg
 github.com/magefile/mage/sh
-# github.com/mendersoftware/go-lib-micro v0.0.0-20210311084510-06d0c5918746
+# github.com/mendersoftware/go-lib-micro v0.0.0-20210317131202-d8b47cfebb37
 ## explicit
 github.com/mendersoftware/go-lib-micro/ws
 github.com/mendersoftware/go-lib-micro/ws/filetransfer
 github.com/mendersoftware/go-lib-micro/ws/menderclient
+github.com/mendersoftware/go-lib-micro/ws/portforward
 github.com/mendersoftware/go-lib-micro/ws/shell
 # github.com/pkg/errors v0.9.1
 ## explicit

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,7 +12,7 @@ github.com/gorilla/websocket
 # github.com/magefile/mage v1.10.0
 github.com/magefile/mage/mg
 github.com/magefile/mage/sh
-# github.com/mendersoftware/go-lib-micro v0.0.0-20210317131202-d8b47cfebb37
+# github.com/mendersoftware/go-lib-micro v0.0.0-20210319123318-8cee8f55d7f5
 ## explicit
 github.com/mendersoftware/go-lib-micro/ws
 github.com/mendersoftware/go-lib-micro/ws/filetransfer


### PR DESCRIPTION
I realized while reviewing your pr (mendersoftware/mender-connect#15) that the handler should be converted to a SessionHandler interface to make sure that resources are deallocated when the session is closed. To this end, I figured that instead of spamming the PR with loose suggestions, I'll make a simple implementation of my desired implementation.